### PR TITLE
Correct misspelling of architectures field name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Nordic nRF24L01(+) debug library for Arduino
 paragraph=This nRF24L01 debug library prints nRF24L01 registers which is useful during development.
 category=Communication
 url=https://github.com/Erriez/ArduinoLibraryNRF24L01Debug
-architecture=*
+architectures=*


### PR DESCRIPTION
The correct spelling of the field name is architectures, not architecture.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format